### PR TITLE
Add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto-generated files
+/docs/ linguist-generated=true


### PR DESCRIPTION
This change makes it possible for GitHub to know to skip showing the
diff for autogenerated files. #none